### PR TITLE
Fix Enhanced AC-3 metadata bitrate calculation (2x value + Int32 overflow)

### DIFF
--- a/Cavern.Format/Transcoders/EnhancedAC3Header/GetMetadata.cs
+++ b/Cavern.Format/Transcoders/EnhancedAC3Header/GetMetadata.cs
@@ -15,7 +15,7 @@ namespace Cavern.Format.Transcoders {
                 new ReadableMetadataField("frmsiz", "Frame size (in 16-bit words)", WordsPerSyncframe),
                 new ReadableMetadataField("frmsiz (in b/f)", $"Bytes per {Blocks * 256} samples", (WordsPerSyncframe << 1) + " B"),
                 new ReadableMetadataField("frmsiz (in kb/s)", $"Track bitrate",
-                    (WordsPerSyncframe << 5) * SampleRate / (Blocks * 256 * 1024) + " kbps"),
+                    (((long)WordsPerSyncframe << 4) * SampleRate / ((double)Blocks * 256 * 1000)).ToString("0.###") + " kbps"),
                 new ReadableMetadataField("fscod", "Sample rate code", SampleRateCode),
                 new ReadableMetadataField("fscod (decoded)", "Sample rate", SampleRate + " Hz"),
                 new ReadableMetadataField("numblks", "Number of audio blocks per frace", Blocks),


### PR DESCRIPTION
Fixes #285.

This PR corrects the Enhanced AC-3 metadata bitrate calculation in  
[`GetMetadata.cs` (line 18)](https://github.com/VoidXH/Cavern/blob/bbb3148/Cavern.Format/Transcoders/EnhancedAC3Header/GetMetadata.cs#L18).

Changes:
- Use `(long)WordsPerSyncframe << 4` (16 bits per word) instead of `<< 5`
  to avoid doubling the bitrate (e.g., 448 → 896 kbps).
- Promote intermediate arithmetic to `long` to avoid `Int32` overflow.
- Use decimal kb/s (1000) as defined in ETSI TS 102 366 V1.4.1 (2017-09), Section F.6.2.2.
- Format output using `ToString("0.###")`.

Verification:
- `dotnet build Cavern.Format/Cavern.Format.csproj -c Release` succeeds.
- Tested using a 1024 kbps E-AC-3 (Atmos) stream:
  - MediaInfo: 1024 kb/s
  - Cavernize (before fix): -730 kb/s
  - Cavernize (after fix): 1024 kb/s