### PR TITLE
Fix silent LFE channel when Cavernize upconversion is enabled

### DIFF
--- a/Cavern/Remapping/CavernizeUpmixer.cs
+++ b/Cavern/Remapping/CavernizeUpmixer.cs
@@ -52,6 +52,10 @@ namespace Cavern.Remapping {
             for (int i = 0; i < filters.Length; i++) {
                 filters[i] = new Cavernize(sampleRate, crossoverFrequency);
                 IntermediateSources[2 * i].Position = sources[i].Position;
+                if (sources[i].LFE) {
+                    IntermediateSources[2 * i].LFE = true;
+                    IntermediateSources[2 * i + 1].LFE = true;
+                }
             }
             SetupCollection(sources, sampleRate);
         }


### PR DESCRIPTION
Rendering a channel-based track with Cavernize upconversion enabled produces a **completely silent LFE output channel**.
The LFE audio is not lost but is rendered as a point source into the front-left corner of the room instead.

`CavernizeUpmixer`, copies only the position onto the new  `StreamMasterSource` objects created by the `Upmixer` base. `MixToLFE` is never reached, and the spatial loop below skips LFE outputs, so no source can contribute to the LFE channel.
The LFE source is instead panned from its nominal position, which dumps the whole LFE track into the front-left group.

Beyond the silent channel, this has three consequences: the LFE never receives the +10 dB it would get at playback, the front-left channel gains the LFE's full energy on top of its own (a clipping risk), and that extra energy drives the `Normalizer ` limiter harder, attenuating the entire render.